### PR TITLE
Fix JSONSH_SOURCED detection for bash, and --get-string mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,11 @@ before_install:
         sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true
         brew update
     fi
-    for P in $SHELL_PROGS ; do brew install $P || brew install homebrew/cask/$P ; done
+    for P in $SHELL_PROGS ; do
+      if ! command -v "$P" ; then
+        brew install $P || brew install homebrew/cask/$P
+      fi
+    done
   fi
 
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install bash ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ before_install:
     if [ "$HOMEBREW_NO_AUTO_UPDATE" = 1 ] ; then
         echo "NOT CALLING 'brew update' as it takes too long and cleans up preinstalled env"
         export HOMEBREW_NO_AUTO_UPDATE
+        HOMEBREW_NO_INSTALL_CLEANUP=1
+        export HOMEBREW_NO_INSTALL_CLEANUP
+        HOMEBREW_NO_UPGRADE_CLEANUP=1
+        export HOMEBREW_NO_UPGRADE_CLEANUP
     else
         unset HOMEBREW_NO_AUTO_UPDATE
         sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ matrix:
 
 # Currently there is no brew for busybox, ash ...
 before_install:
+- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true ; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true ; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew update ; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install $SHELL_PROGS ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true ; fi
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true ; fi
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew update ; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install $SHELL_PROGS ; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then for P in $SHELL_PROGS ; do brew install $P || brew install homebrew/cask/$P ; done ; fi
 
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install bash ; fi
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install dash ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,9 @@ matrix:
 
 # Currently there is no brew for busybox, ash ...
 before_install:
-- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true ; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true ; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew update ; fi
+#- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true ; fi
+#- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true ; fi
+#- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew update ; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install $SHELL_PROGS ; fi
 
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install bash ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,15 @@ before_install:
         brew update
     fi
     for P in $SHELL_PROGS ; do
-      if ! command -v "$P" ; then
-        brew install $P || brew install homebrew/cask/$P
+      if command -v "$P" ; then
+        case "$P" in
+          bash) case "`bash -c 'echo $BASH_VERSION'`" in
+            1.*|2.*|3.*) ;; ### Too old, fall through to install new
+            *) continue ;;
+          *) continue ;;
+        esac
       fi
+      brew install $P || brew install homebrew/cask/$P || brew install --build-from-source $P
     done
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,13 @@ addons:
 ###      - ksh
 
 env:
-#  global:
+  global:
+    - CI_DEFAULT_HOMEBREW_NO_AUTO_UPDATE=1
+      # By default, avoid updating (including cleaning) osx worker beside what
+      # we require to install, compared to what Travis provides. Technically
+      # we can call master branch builds sometimes to update the workers cache
+      # of packages by manual or timer-driven runs with explicit setting like
+      # HOMEBREW_NO_AUTO_UPDATE=0
 #    - DEBUG=99
 #    - TEST_PATTERN='test/*.sh'
   matrix:
@@ -63,10 +69,20 @@ matrix:
 
 # Currently there is no brew for busybox, ash ...
 before_install:
-#- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true ; fi
-#- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true ; fi
-#- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew update ; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then for P in $SHELL_PROGS ; do brew install $P || brew install homebrew/cask/$P ; done ; fi
+- |-
+  if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+    [ -n "$HOMEBREW_NO_AUTO_UPDATE" ] || HOMEBREW_NO_AUTO_UPDATE="$CI_DEFAULT_HOMEBREW_NO_AUTO_UPDATE"
+    if [ "$HOMEBREW_NO_AUTO_UPDATE" = 1 ] ; then
+        echo "NOT CALLING 'brew update' as it takes too long and cleans up preinstalled env"
+        export HOMEBREW_NO_AUTO_UPDATE
+    else
+        unset HOMEBREW_NO_AUTO_UPDATE
+        sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true
+        sudo git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true
+        brew update
+    fi
+    for P in $SHELL_PROGS ; do brew install $P || brew install homebrew/cask/$P ; done
+  fi
 
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install bash ; fi
 #- if [ "$TRAVIS_OS_NAME" = "osx" ] ; then brew install dash ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,13 @@ before_install:
     for P in $SHELL_PROGS ; do
       if command -v "$P" ; then
         case "$P" in
-          bash) case "`bash -c 'echo $BASH_VERSION'`" in
-            1.*|2.*|3.*) ;; ### Too old, fall through to install new
-            *) continue ;;
+          bash)
+            case "`bash -c 'echo $BASH_VERSION'`" in
+              1.*|2.*|3.*)
+                ### Rather old, fall through to install new. But test both :)
+                SHELL_PROGS="$SHELL_PROGS `command -v "$P"`" ;;
+              *) continue ;;
+            esac ;;
           *) continue ;;
         esac
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ matrix:
 ### Currently the syntax of ksh needs too many syntax adaptations vs other shells
 #  - os: macos
 #    env: SHELL_PROGS=ksh
-  allow_failures:
-  - os: macos
+#  allow_failures:
+#  - os: macos
 #  - env: SHELL_PROGS=zsh
 #  - env: SHELL_PROGS=busybox
 #  - env: SHELL_PROGS=ksh

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,9 @@ matrix:
 #  - os: macos
 #    env: SHELL_PROGS=ksh
   allow_failures:
-  - env: SHELL_PROGS=zsh
-  - env: SHELL_PROGS=busybox
+  - os: macos
+#  - env: SHELL_PROGS=zsh
+#  - env: SHELL_PROGS=busybox
 #  - env: SHELL_PROGS=ksh
 #  - env: SHELL_PROGS=ksh88
 #  - env: SHELL_PROGS=ksh93

--- a/JSON.sh
+++ b/JSON.sh
@@ -479,7 +479,13 @@ parse_options() {
   validate_debuglevel
 
   # For normalized data, we do the whole job and just return the top object
-  [ "$NORMALIZE" = 1 ] && BRIEF=0 && LEAFONLY=0 && PRUNE=0
+  if [ "$NORMALIZE" = 1 ]; then
+    BRIEF=0
+    LEAFONLY=0
+    PRUNE=0
+  fi
+
+  return 0
 }
 
 awk_egrep() {

--- a/JSON.sh
+++ b/JSON.sh
@@ -139,9 +139,16 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
             #set | sort >&2
             if  [ "$0" = "${BASH_SOURCE[0]}" ] || [ "$0" = "$BASH_SOURCE" ] ; then
                 JSONSH_SOURCED=no
-            fi
-            if  [ -n "${BASH-}" ] && [ "$0" = "-bash" ] ; then
-                JSONSH_SOURCED=yes
+            else
+                if  [ -n "${BASH-}" ] ; then
+                    case "$0" in
+                        bash|-bash|*bin/bash|sh|-sh|*bin/sh)
+                            JSONSH_SOURCED=yes ;;
+                        *)  echo "WARNING: Assuming JSONSH_SOURCED=no and running as a standalone bash script" >&2
+                            JSONSH_SOURCED=no
+                            ;;
+                    esac
+                fi
             fi
             # In other cases so far, we just don't know for sure.
             # The BASH_SOURCE array may have 2+ entries for higher-layer

--- a/JSON.sh
+++ b/JSON.sh
@@ -149,8 +149,11 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
                         bash|-bash|*bin/bash|sh|-sh|*bin/sh|"$BASH")
                             # Likely sourced into interactive shell (maybe via profile)
                             JSONSH_SOURCED=yes ;;
-                        *)  echo "WARNING: Assuming JSONSH_SOURCED=no and running as a standalone bash script ($0)" >&2
+                        *JSON.sh*)  echo "WARNING: Assuming JSONSH_SOURCED=no and running as a standalone bash script ($0)" >&2
                             JSONSH_SOURCED=no
+                            ;;
+                        *)  echo "WARNING: Assuming JSONSH_SOURCED=yes and running as an inclusion into another bash script ($0)" >&2
+                            JSONSH_SOURCED=yes
                             ;;
                     esac
                 fi

--- a/JSON.sh
+++ b/JSON.sh
@@ -146,7 +146,8 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
             else
                 if  [ -n "${BASH-}" ] ; then
                     case "$0" in
-                        bash|-bash|*bin/bash|sh|-sh|*bin/sh)
+                        bash|-bash|*bin/bash|sh|-sh|*bin/sh|"$BASH")
+                            # Likely sourced into interactive shell (maybe via profile)
                             JSONSH_SOURCED=yes ;;
                         *)  echo "WARNING: Assuming JSONSH_SOURCED=no and running as a standalone bash script" >&2
                             JSONSH_SOURCED=no

--- a/JSON.sh
+++ b/JSON.sh
@@ -139,7 +139,9 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
         bash)
             # All this weird parsing because busybox sh can't handle a
             # ${BASH_SOURCE[0]} in a codepath it does not even execute
-            if  [ "$0" = "$BASH_SOURCE" ] || set | grep -E '^BASH_SOURCE=\(.*\]="'"$0"'"' >/dev/null ; then
+            if  [ "$0" = "$BASH_SOURCE" ] || set | grep -E '^BASH_SOURCE=\(\[0\]="'"$0"'"' >/dev/null ; then
+                # (Top-most) executed script filename is same as this
+                # source filename for JSON.sh => standalone script mode
                 JSONSH_SOURCED=no
             else
                 if  [ -n "${BASH-}" ] ; then

--- a/JSON.sh
+++ b/JSON.sh
@@ -947,9 +947,9 @@ parse_value() {
   fi
 
   print_debug $DEBUGLEVEL_PRINTPATHVAL \
-	"JPATH='$jpath' VALUE='$value' B='$BRIEF'" \
-	"isleaf='$isleaf'/L='$LEAFONLY' isempty='$isempty'/P='$PRUNE':" \
-	"print='$print'" >&2
+    "JPATH='$jpath' VALUE='$value' B='$BRIEF'" \
+    "isleaf='$isleaf'/L='$LEAFONLY' isempty='$isempty'/P='$PRUNE':" \
+    "print='$print'" >&2
 
   if [ "$print" -gt 0 ] ; then
     if [ -n "$SHELLABLE_OUTPUT" ]; then

--- a/JSON.sh
+++ b/JSON.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2014-2015 Dominic Tarr
-# Copyright (C) 2015-2020 Eaton
+# Copyright (C) 2014-2018 Dominic Tarr and other contributors to upstream code
+# Copyright (C) 2015-2021 Eaton
 #
 #! \file    JSON.sh
 #  \brief   A json parser written in shell-script

--- a/JSON.sh
+++ b/JSON.sh
@@ -194,7 +194,7 @@ throw() {
   exit 1
 }
 
-TABCHAR="`printf '\t'`"
+TABCHAR="$(printf '\t')"
 
 BRIEF=0
 LEAFONLY=0

--- a/JSON.sh
+++ b/JSON.sh
@@ -134,7 +134,7 @@ esac
 
 # TODO: detect having been sourced into non-bash shells?
 if [ -z "${JSONSH_SOURCED-}" ]; then
-    if [ -n "${DEBUG-}" ] && [ "$DEBUG" != 0 ] && [ "$DEBUG" != no ]; then set | egrep '^[A-Za-z0-9_].*=' | sort >&2 ; fi
+    if [ -n "${DEBUG-}" ] && [ "$DEBUG" != 0 ] && [ "$DEBUG" != no ]; then set | grep -E '^[A-Za-z0-9_].*=' | sort >&2 ; fi
     case "$SHELL_BASENAME" in
         bash)
             # All this weird parsing because busybox sh can't handle a
@@ -653,7 +653,7 @@ tokenize() {
   local SPACE='[[:space:]]+'
 
   # Force zsh to expand $GREP_O into multiple words
-  is_wordsplit_disabled="$(unsetopt 2>/dev/null | grep -c '^shwordsplit$')"
+  is_wordsplit_disabled="$(unsetopt 2>/dev/null | grep -Ec '^shwordsplit$')"
   if [ "$is_wordsplit_disabled" != 0 ]; then setopt shwordsplit; fi
   # Note: we do not fail for empty documents (including whitespace-only) here
   # The pedantic mode handles that if desired by caller
@@ -718,7 +718,7 @@ $value"
     # the result is filtered for final output with another pass,
     # where we might indent it below.
     # Force zsh to expand $SORTDATA* into multiple words
-    is_wordsplit_disabled="$(unsetopt 2>/dev/null | grep -c '^shwordsplit$')"
+    is_wordsplit_disabled="$(unsetopt 2>/dev/null | grep -Ec '^shwordsplit$')"
     if [ "$is_wordsplit_disabled" != 0 ]; then setopt shwordsplit; fi
     ary="$(printf '%s\n' "$aryml" | $SORTDATA_ARR | tr '\n' ',' | $GSED 's|,*$||' 2>/dev/null | $GSED 's|^,*||' 2>/dev/null)"
     if [ "$is_wordsplit_disabled" != 0 ]; then unsetopt shwordsplit; fi
@@ -796,7 +796,7 @@ $key:$value"
     # the result is filtered for final output with another pass,
     # where we might indent it below.
     # Force zsh to expand $SORTDATA* into multiple words
-    is_wordsplit_disabled="$(unsetopt 2>/dev/null | grep -c '^shwordsplit$')"
+    is_wordsplit_disabled="$(unsetopt 2>/dev/null | grep -Ec '^shwordsplit$')"
     if [ "$is_wordsplit_disabled" != 0 ]; then setopt shwordsplit; fi
     obj="$(printf '%s\n' "$objml" | $SORTDATA_OBJ | tr '\n' ',' | $GSED 's|,*$||' 2>/dev/null | $GSED 's|^,*||' 2>/dev/null)"
     if [ "$is_wordsplit_disabled" != 0 ]; then unsetopt shwordsplit; fi

--- a/JSON.sh
+++ b/JSON.sh
@@ -683,6 +683,7 @@ parse_array() {
       while :
       do
         INDENT="${INDENT_NEXT}" parse_value "$1" "$index"
+        if $QUICK_ABORT ; then return 0 ; fi
         index="$(expr $index + 1)"
         if [ "$PRETTYPRINT" = 1 ]; then
             [ -z "$ary" ] && ary="${INDENT_NEXT}$value" || ary="$ary
@@ -760,6 +761,7 @@ parse_object() {
         read -r token
         print_debug $DEBUGLEVEL_PRINTTOKEN "parse_object(3):" "token='$token'"
         INDENT="${INDENT_NEXT}" parse_value "$1" "$key"
+        if $QUICK_ABORT ; then return 0 ; fi
         if [ "$PRETTYPRINT" = 1 ]; then
             [ -z "$obj" ] && obj="${INDENT_NEXT}$key${PRETTYPRINT_OBJSEP}$value" || obj="$obj
 ${INDENT_NEXT}$key${PRETTYPRINT_OBJSEP}$value"

--- a/JSON.sh
+++ b/JSON.sh
@@ -260,7 +260,8 @@ usage() {
   echo "     around values to ease backticked picking of exact data path items"
   echo '     into scripts (non-exact matches will be same as multiword text):'
   echo '     VALUE="$(JSON.sh --shellable-output=strings -x '"'"'^"field"$'"'"')"'
-  echo "--shellable-output=string - same but returns one string (first hit if any)"
+  echo "--shellable-output=string - same but returns one string (first hit if any,"
+  echo "     so if you need one exact match, specify it like '^"'"repository","url"$'"')"
   echo "--shellable-output=arrays - Do not print the path column, add quotes:"
   echo '     ARR=( $(JSON.sh --shellable-output=arrays -x '"'"'^"array",[0-9]'"'"') )'
   echo "--get-string 'regex' - Alias to -l -x 'regex' --shellable-output=string"

--- a/JSON.sh
+++ b/JSON.sh
@@ -137,7 +137,7 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
     case "$SHELL_BASENAME" in
         bash)
             #set | sort >&2
-            if  [ "$0" = "$BASH_SOURCE[0]" ] || [ "$0" = "$BASH_SOURCE" ] ; then
+            if  [ "$0" = "${BASH_SOURCE[0]}" ] || [ "$0" = "$BASH_SOURCE" ] ; then
                 JSONSH_SOURCED=no
             fi
             if  [ -n "${BASH-}" ] && [ "$0" = "-bash" ] ; then

--- a/JSON.sh
+++ b/JSON.sh
@@ -137,7 +137,9 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
     if [ -n "${DEBUG-}" ] && [ "$DEBUG" != 0 ] && [ "$DEBUG" != no ]; then set | egrep '^[A-Za-z0-9_].*=' | sort >&2 ; fi
     case "$SHELL_BASENAME" in
         bash)
-            if  [ "$0" = "${BASH_SOURCE[0]}" ] || [ "$0" = "$BASH_SOURCE" ] ; then
+            # All this weird parsing because busybox sh can't handle a
+            # ${BASH_SOURCE[0]} in a codepath it does not even execute
+            if  [ "$0" = "$BASH_SOURCE" ] || set | grep -E '^BASH_SOURCE=\(.*\]="'"$0"'"' >/dev/null ; then
                 JSONSH_SOURCED=no
             else
                 if  [ -n "${BASH-}" ] ; then

--- a/JSON.sh
+++ b/JSON.sh
@@ -134,9 +134,9 @@ esac
 
 # TODO: detect having been sourced into non-bash shells?
 if [ -z "${JSONSH_SOURCED-}" ]; then
+    if [ -n "${DEBUG-}" ] && [ "$DEBUG" != 0 ] && [ "$DEBUG" != no ]; then set | egrep '^[A-Za-z0-9_].*=' | sort >&2 ; fi
     case "$SHELL_BASENAME" in
         bash)
-            #set | sort >&2
             if  [ "$0" = "${BASH_SOURCE[0]}" ] || [ "$0" = "$BASH_SOURCE" ] ; then
                 JSONSH_SOURCED=no
             else

--- a/JSON.sh
+++ b/JSON.sh
@@ -1095,19 +1095,11 @@ jsonsh_debugging_defaults
 
 # If NOT sourced into a bash script, parse stdin and quit
 # Beware that this hangs waiting for input if there is no stdin
-#[ "${JSONSH_SOURCED-}" != yes ] || \
-#if  [ "$0" = "$BASH_SOURCE[0]" ] || [ "$0" = "$BASH_SOURCE" ] || [ -z "${BASH-}" ] || [ -z "$BASH_SOURCE" ]; \
 if [ "${JSONSH_SOURCED-}" != yes ]
 then
   jsonsh_cli "$@"
   exit $?
 fi
-
-# Else if sourced, stay dormant until called to work via a routine
-#if ([ "$0" = "$BASH_SOURCE" ] || ! [ -n "$BASH_SOURCE" ]);
-#then
-#  parse_options "$@"
-#  tokenize | parse
-#fi
+# ...else if sourced, stay dormant until called to work via a routine
 
 # vi: expandtab sw=2 ts=2

--- a/JSON.sh
+++ b/JSON.sh
@@ -99,6 +99,10 @@ case "$SHELL_BASENAME" in
     bash)
         SHELL_REGEX=yes
         SHELL_TWOSLASH=yes
+        # bash 3.x does not support unquoted mode, newer supports both
+        if [ "/" = "$(S='\/' ; echo ${S//\\\//\/})" ]; then
+            SHELL_TWOSLASH=unquoted
+        fi
         SHELL_PIPEFAIL='set -o pipefail'
         ;;
     dash|ash) # The spartan bare minimum

--- a/JSON.sh
+++ b/JSON.sh
@@ -901,7 +901,7 @@ parse_value() {
                 case "$SHELL_TWOSLASH" in
                     yes|quoted) value="${value//\\\//\/}" ;;
                     unquoted) value=${value//\\\//\/} ;;
-                    *) value="$(echo "$value" | $GSED 's#\\/#/#g')" ;;
+                    *) value="$(echo "$value" | $GSED 's#\\\/#/#g')" ;;
                 esac
             fi
        fi
@@ -914,7 +914,7 @@ parse_value() {
             case "$SHELL_TWOSLASH" in
                 yes|quoted) value="${value//\\\//\/}" ;;
                 unquoted) value=${value//\\\//\/} ;;
-                *) value="$(echo "$value" | $GSED 's#\\/#/#g')" ;;
+                *) value="$(echo "$value" | $GSED 's#\\\/#/#g')" ;;
             esac
        fi
        isleaf=1

--- a/JSON.sh
+++ b/JSON.sh
@@ -149,7 +149,7 @@ if [ -z "${JSONSH_SOURCED-}" ]; then
                         bash|-bash|*bin/bash|sh|-sh|*bin/sh|"$BASH")
                             # Likely sourced into interactive shell (maybe via profile)
                             JSONSH_SOURCED=yes ;;
-                        *)  echo "WARNING: Assuming JSONSH_SOURCED=no and running as a standalone bash script" >&2
+                        *)  echo "WARNING: Assuming JSONSH_SOURCED=no and running as a standalone bash script ($0)" >&2
                             JSONSH_SOURCED=no
                             ;;
                     esac

--- a/JSON.sh
+++ b/JSON.sh
@@ -136,12 +136,18 @@ esac
 if [ -z "${JSONSH_SOURCED-}" ]; then
     case "$SHELL_BASENAME" in
         bash)
+            #set | sort >&2
             if  [ "$0" = "$BASH_SOURCE[0]" ] || [ "$0" = "$BASH_SOURCE" ] ; then
                 JSONSH_SOURCED=no
             fi
             if  [ -n "${BASH-}" ] && [ "$0" = "-bash" ] ; then
                 JSONSH_SOURCED=yes
             fi
+            # In other cases so far, we just don't know for sure.
+            # The BASH_SOURCE array may have 2+ entries for higher-layer
+            # script names (meaning there are some levels above).
+            # The $0 may be some such script name, or "bash" without "-"
+            # for sourcing into current shell without a script file...
             ;;
         *)  JSONSH_SOURCED=no ;;
     esac
@@ -1050,6 +1056,7 @@ jsonsh_cli() {
   # NOTE: If the caller sets up some specific different debugging envvars
   # then consider changing JSONSH_DEBUGGING_SETUP and JSONSH_DEBUGGING_REPORT
   # to e.g. "notdone" as well
+  # Beware that this hangs waiting for input if there is no stdin piped here
   parse_options "$@"
   jsonsh_debugging_setup
   jsonsh_debugging_report
@@ -1080,6 +1087,7 @@ jsonsh_cli_subshell() (
 jsonsh_debugging_defaults
 
 # If NOT sourced into a bash script, parse stdin and quit
+# Beware that this hangs waiting for input if there is no stdin
 #[ "${JSONSH_SOURCED-}" != yes ] || \
 #if  [ "$0" = "$BASH_SOURCE[0]" ] || [ "$0" = "$BASH_SOURCE" ] || [ -z "${BASH-}" ] || [ -z "$BASH_SOURCE" ]; \
 if [ "${JSONSH_SOURCED-}" != yes ]
@@ -1088,6 +1096,7 @@ then
   exit $?
 fi
 
+# Else if sourced, stay dormant until called to work via a routine
 #if ([ "$0" = "$BASH_SOURCE" ] || ! [ -n "$BASH_SOURCE" ]);
 #then
 #  parse_options "$@"

--- a/all-tests.sh
+++ b/all-tests.sh
@@ -70,6 +70,7 @@ if [ "$is_wordsplit_disabled" != 0 ]; then setopt shwordsplit; fi
 
 for SHELL_PROG in $SHELL_PROGS ; do
     case "$SHELL_PROG" in
+        busybox_sh) SHELL_PROG="busybox sh" ;;
         busybox|*/busybox) SHELL_PROG="$SHELL_PROG sh" ;;
         ' '|'-') SHELL_PROG='' ;; # system default shell
     esac

--- a/test/parse-test.sh
+++ b/test/parse-test.sh
@@ -12,7 +12,7 @@ ptest () {
 
 fails=0
 i=0
-echo "1..7"
+echo "1..10"
 for input in \
     '"oooo"  ' \
     '[true, 1, [0, {}]]  ' \
@@ -69,6 +69,46 @@ if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = 'https://github.com/dominictarr/JS
   echo "ok $i - package.json with extraction of first of several entries with unquoted string markup"
 else
   echo "not ok $i - Parsing package.json with extraction of first of several entries with unquoted string markup failed ($JSONSH_RES)!"
+  echo "==="
+  echo "$JSONSH_OUT"
+  echo "==="
+  fails="$(expr $fails + 1)"
+fi
+
+### Several modes of calling the script code, sourced or externalized
+i="$(expr $i + 1)"
+JSONSH_OUT="$(jsonsh_cli --get-string '^"repository","url"$' < ../package.json 2>/dev/null)" \
+&& [ -n "$JSONSH_OUT" ] ; JSONSH_RES=$?
+if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = 'https://github.com/dominictarr/JSON.sh.git' ] ; then
+  echo "ok $i - package.json with extraction of a string by path, with jsonsh_cli() sourced method"
+else
+  echo "not ok $i - Parsing package.json with extraction of a string by path, with jsonsh_cli() sourced method, failed ($JSONSH_RES)!"
+  echo "==="
+  echo "$JSONSH_OUT"
+  echo "==="
+  fails="$(expr $fails + 1)"
+fi
+
+i="$(expr $i + 1)"
+JSONSH_OUT="$(jsonsh_cli_subshell --get-string '^"repository","url"$' < ../package.json 2>/dev/null)" \
+&& [ -n "$JSONSH_OUT" ] ; JSONSH_RES=$?
+if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = 'https://github.com/dominictarr/JSON.sh.git' ] ; then
+  echo "ok $i - package.json with extraction of a string by path, with jsonsh_cli_subshell() sourced method"
+else
+  echo "not ok $i - Parsing package.json with extraction of a string by path, with jsonsh_cli_subshell() sourced method, failed ($JSONSH_RES)!"
+  echo "==="
+  echo "$JSONSH_OUT"
+  echo "==="
+  fails="$(expr $fails + 1)"
+fi
+
+i="$(expr $i + 1)"
+JSONSH_OUT="$($SHELL_PROG ../JSON.sh --get-string '^"repository","url"$' < ../package.json 2>/dev/null)" \
+&& [ -n "$JSONSH_OUT" ] ; JSONSH_RES=$?
+if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = 'https://github.com/dominictarr/JSON.sh.git' ] ; then
+  echo "ok $i - package.json with extraction of a string by path, with $SHELL_PROG ../JSON.sh forked-script method"
+else
+  echo "not ok $i - Parsing package.json with extraction of a string by path, with $SHELL_PROG ../JSON.sh forked-script method, failed ($JSONSH_RES)!"
   echo "==="
   echo "$JSONSH_OUT"
   echo "==="

--- a/test/parse-test.sh
+++ b/test/parse-test.sh
@@ -43,7 +43,7 @@ JSONSH_OUT="$(jsonsh_cli --shellable-output=strings -x '^"name"$' < ../package.j
 if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = 'JSON.sh' ] ; then
   echo "ok $i - package.json with extraction of one entry"
 else
-  echo "not ok $i - Parsing package.json with extraction of one entry failed!"
+  echo "not ok $i - Parsing package.json with extraction of one entry failed ($JSONSH_RES)!"
   fails="$(expr $fails + 1)"
 fi
 
@@ -54,7 +54,7 @@ if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = '"https://github.com/dominictarr/J
 "git"' ] ; then
   echo "ok $i - package.json with extraction of several entries with array markup"
 else
-  echo "not ok $i - Parsing package.json with extraction of several entries with array markup failed!"
+  echo "not ok $i - Parsing package.json with extraction of several entries with array markup failed ($JSONSH_RES)!"
   echo "==="
   echo "$JSONSH_OUT"
   echo "==="
@@ -68,7 +68,7 @@ JSONSH_OUT="$(jsonsh_cli -So=-r --get-string '^"repository"' < ../package.json 2
 if [ "$JSONSH_RES" = 0 ] && [ "$JSONSH_OUT" = 'https://github.com/dominictarr/JSON.sh.git' ] ; then
   echo "ok $i - package.json with extraction of first of several entries with unquoted string markup"
 else
-  echo "not ok $i - Parsing package.json with extraction of first of several entries with unquoted string markup failed!"
+  echo "not ok $i - Parsing package.json with extraction of first of several entries with unquoted string markup failed ($JSONSH_RES)!"
   echo "==="
   echo "$JSONSH_OUT"
   echo "==="


### PR DESCRIPTION
There was a regression of sort when backporting recent developments into a product that lagged a few years behind, that sourcing the script (without pre-setting `JSONSH_SOURCED=yes` in that older codebase) tended to run its payload and exit, as if it were a standalone script. With no stdin at that point, it was hanging with `cat`.

Another issue was looking for `--get-string` hits without sorting/normalization - it yielded errors without handling `QUICK_ABORT` soon enough.